### PR TITLE
Handle grsecurity restriction on patched kernels

### DIFF
--- a/deleteSeedboxUser
+++ b/deleteSeedboxUser
@@ -43,7 +43,7 @@ done
 # 3.1.1
 
 #kill all processes related to that user
-sudo kill -9 $( ps -ef | grep $NEWUSER1 | awk '{ print $2 }' )
+sudo kill -9 $( sudo ps -ef | grep $NEWUSER1 | awk '{ print $2 }' )
 
 # 3.2
 


### PR DESCRIPTION
Elevate ps command during kill to handle grsecurity patched kernels.  grsecurity patches /proc and process id access so that non-root users can't see other user processes and this prevents the script from working properly.  Also for some reason sudo isn't propagated to the child process on that line.

Stock OVH kernels are patched with grsecurity.
